### PR TITLE
Add courseservice tests

### DIFF
--- a/tests/EduManagementLab.Core.Tests/EduManagementLab.Core.Tests.csproj
+++ b/tests/EduManagementLab.Core.Tests/EduManagementLab.Core.Tests.csproj
@@ -8,6 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">

--- a/tests/EduManagementLab.Core.Tests/Services/CourseServiceTests.cs
+++ b/tests/EduManagementLab.Core.Tests/Services/CourseServiceTests.cs
@@ -1,89 +1,107 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 using EduManagementLab.Core.Services;
 using EduManagementLab.EfRepository;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using EduManagementLab.Core.Entities;
+using System.Linq;
 
 namespace EduManagementLab.Core.Tests.Services
 {
     public class CourseServiceTests
     {
-        [Fact]
-        public void CreateCourse()
-        {
+        private readonly DbContextOptions<DataContext> _contextOptions;
 
-            string databaseName = "EduManagementLabDb_Test_CreteUpdateAndGetUser";
-            var dbContextOptions = new DbContextOptionsBuilder<DataContext>()
-                .UseSqlServer(@$"Server=(localdb)\mssqllocaldb;Database={databaseName};Trusted_Connection=True;MultipleActiveResultSets=true")
+
+        public CourseServiceTests()
+        {
+            _contextOptions = new DbContextOptionsBuilder<DataContext>()
+                .UseInMemoryDatabase("CourseServiceTest")
+                .ConfigureWarnings(b => b.Ignore(InMemoryEventId.TransactionIgnoredWarning))
                 .Options;
 
-            var dataContext = new DataContext(dbContextOptions);
+            using var context = new DataContext(_contextOptions);
 
-            dataContext.Database.EnsureDeleted();
-            dataContext.Database.EnsureCreated();
+            context.Database.EnsureDeleted();
+            context.Database.EnsureCreated();
 
-            var unitOfWorkCreate = new UnitOfWork(dataContext);
-            var courseServiceCreate = new CourseService(unitOfWorkCreate);
-            var createdCourse = courseServiceCreate.CreateCourse("AAA", "CourseName", "CourseDescription", DateTime.Today, DateTime.Today);
+            context.AddRange(
+                new Course { Id = Guid.Parse("4E228873-0468-4BE6-A14B-48DE5E7CFFFB"), Code = "AAA", Name = "CourseNameOne", Description = "CourseDescriptionOne", StartDate = DateTime.MinValue, EndDate = DateTime.MaxValue },
+                new Course { Id = Guid.Parse("4A0E4335-08E0-45C0-8A97-9791CE81E73D"), Code = "BBB", Name = "CourseNameTwo", Description = "CourseDescriptionTwo", StartDate = DateTime.MinValue, EndDate = DateTime.MaxValue });
 
-            var unitOfWorkGet = new UnitOfWork(dataContext);
+            context.SaveChanges();
+        }
+
+        [Fact]
+        public void GetCourse()
+        {
+            using var context = CreateContext();
+
+            var unitOfWorkGet = new UnitOfWork(context);
             var courseServiceGet = new CourseService(unitOfWorkGet);
-            var fetchedCourse = courseServiceGet.GetCourse(createdCourse.Id);
+            var fetchedCourse = courseServiceGet.GetCourse(Guid.Parse("4E228873-0468-4BE6-A14B-48DE5E7CFFFB"));
 
             Assert.NotNull(fetchedCourse);
-            Assert.Equal("AAA", createdCourse.Code);
-            Assert.Equal("CourseName", createdCourse.Name);
-            Assert.Equal("CourseDescription", createdCourse.Description);
-            Assert.Equal(DateTime.Today, createdCourse.StartDate);
-            Assert.Equal(DateTime.Today, createdCourse.EndDate);
+            Assert.Equal("AAA", fetchedCourse.Code);
+            Assert.Equal("CourseNameOne", fetchedCourse.Name);
+            Assert.Equal("CourseDescriptionOne", fetchedCourse.Description);
+            Assert.Equal(DateTime.MinValue, fetchedCourse.StartDate);
+            Assert.Equal(DateTime.MaxValue, fetchedCourse.EndDate);
+        }
 
-            dataContext.Database.EnsureDeleted();
+        [Fact]
+        public void GetAllCourses()
+        {
+            using var context = CreateContext();
+
+            var unitOfWorkGet = new UnitOfWork(context);
+            var courseServiceGet = new CourseService(unitOfWorkGet);
+            var fetchedCourses = courseServiceGet.GetCourses();
+
+            Assert.Collection(
+                fetchedCourses,
+                b => Assert.Equal("AAA", b.Code),
+                b => Assert.Equal("BBB", b.Code));
+        }
+
+        [Fact]
+        public void AddCourse()
+        {
+            using var context = CreateContext();
+
+            var unitOfWorkCreate = new UnitOfWork(context);
+            var courseServiceCreate = new CourseService(unitOfWorkCreate);
+            var createdCourse = courseServiceCreate.CreateCourse("CCC", "CourseNameThree", "CourseDescriptionThree", DateTime.Today, DateTime.Today);
+
+            var course = context.Courses.Single(b => b.Code == "CCC");
+            Assert.Equal("CCC", course.Code);
         }
 
         [Fact]
         public void UpdateCourse()
         {
+            using var context = CreateContext();
 
-            string databaseName = "EduManagementLabDb_Test_CreteUpdateAndGetUser";
-            var dbContextOptions = new DbContextOptionsBuilder<DataContext>()
-                .UseSqlServer(@$"Server=(localdb)\mssqllocaldb;Database={databaseName};Trusted_Connection=True;MultipleActiveResultSets=true")
-                .Options;
 
-            var dataContext = new DataContext(dbContextOptions);
-
-            dataContext.Database.EnsureDeleted();
-            dataContext.Database.EnsureCreated();
-
-            var unitOfWorkCreate = new UnitOfWork(dataContext);
-            var courseServiceCreate = new CourseService(unitOfWorkCreate);
-            var createdCourse = courseServiceCreate.CreateCourse("AAA", "CourseName", "CourseDescription", DateTime.Now.AddDays(-2), DateTime.Now.AddDays(2));
-
-            var unitOfWorkUpdate = new UnitOfWork(dataContext);
+            var unitOfWorkUpdate = new UnitOfWork(context);
             var courseServiceUpdate = new CourseService(unitOfWorkUpdate);
 
+            courseServiceUpdate.UpdateCourseInfo(Guid.Parse("4E228873-0468-4BE6-A14B-48DE5E7CFFFB"), "AAB", "ChangedCourseName", "ChangedCourseDescription");
+            courseServiceUpdate.UpdateCoursePeriod(Guid.Parse("4E228873-0468-4BE6-A14B-48DE5E7CFFFB"), DateTime.Today, DateTime.Today);
 
-            courseServiceUpdate.UpdateCourseInfo(createdCourse.Id, "BBB", "ChangedCourseName", "ChangedCourseDescription");
-            courseServiceUpdate.UpdateCoursePeriod(createdCourse.Id, DateTime.Today, DateTime.Today);
 
-            var unitOfWorkGet = new UnitOfWork(dataContext);
-            var courseServiceGet = new CourseService(unitOfWorkGet);
-            var fetchedCourse = courseServiceGet.GetCourse(createdCourse.Id);
+            var course = context.Courses.Single(b => b.Code == "AAB");
 
-            Assert.NotNull(fetchedCourse);
-            Assert.Equal("BBB", createdCourse.Code);
-            Assert.Equal("ChangedCourseName", createdCourse.Name);
-            Assert.Equal("ChangedCourseDescription", createdCourse.Description);
-            Assert.Equal(DateTime.Today, createdCourse.StartDate);
-            Assert.Equal(DateTime.Today, createdCourse.EndDate);
-
-            dataContext.Database.EnsureDeleted();
+            Assert.NotNull(course);
+            Assert.Equal("AAB", course.Code);
+            Assert.Equal("ChangedCourseName", course.Name);
+            Assert.Equal("ChangedCourseDescription", course.Description);
+            Assert.Equal(DateTime.Today, course.StartDate);
+            Assert.Equal(DateTime.Today, course.EndDate);
         }
 
+        DataContext CreateContext() => new DataContext(_contextOptions);
 
     }
-
 }

--- a/tests/EduManagementLab.Core.Tests/Services/CourseServiceTests.cs
+++ b/tests/EduManagementLab.Core.Tests/Services/CourseServiceTests.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+using EduManagementLab.Core.Services;
+using EduManagementLab.EfRepository;
+using Microsoft.EntityFrameworkCore;
+
+namespace EduManagementLab.Core.Tests.Services
+{
+    public class CourseServiceTests
+    {
+        [Fact]
+        public void CreateCourse()
+        {
+
+            string databaseName = "EduManagementLabDb_Test_CreteUpdateAndGetUser";
+            var dbContextOptions = new DbContextOptionsBuilder<DataContext>()
+                .UseSqlServer(@$"Server=(localdb)\mssqllocaldb;Database={databaseName};Trusted_Connection=True;MultipleActiveResultSets=true")
+                .Options;
+
+            var dataContext = new DataContext(dbContextOptions);
+
+            dataContext.Database.EnsureDeleted();
+            dataContext.Database.EnsureCreated();
+
+            var unitOfWorkCreate = new UnitOfWork(dataContext);
+            var courseServiceCreate = new CourseService(unitOfWorkCreate);
+            var createdCourse = courseServiceCreate.CreateCourse("AAA", "CourseName", "CourseDescription", DateTime.Today, DateTime.Today);
+
+            var unitOfWorkGet = new UnitOfWork(dataContext);
+            var courseServiceGet = new CourseService(unitOfWorkGet);
+            var fetchedCourse = courseServiceGet.GetCourse(createdCourse.Id);
+
+            Assert.NotNull(fetchedCourse);
+            Assert.Equal("AAA", createdCourse.Code);
+            Assert.Equal("CourseName", createdCourse.Name);
+            Assert.Equal("CourseDescription", createdCourse.Description);
+            Assert.Equal(DateTime.Today, createdCourse.StartDate);
+            Assert.Equal(DateTime.Today, createdCourse.EndDate);
+
+            dataContext.Database.EnsureDeleted();
+        }
+
+        [Fact]
+        public void UpdateCourse()
+        {
+
+            string databaseName = "EduManagementLabDb_Test_CreteUpdateAndGetUser";
+            var dbContextOptions = new DbContextOptionsBuilder<DataContext>()
+                .UseSqlServer(@$"Server=(localdb)\mssqllocaldb;Database={databaseName};Trusted_Connection=True;MultipleActiveResultSets=true")
+                .Options;
+
+            var dataContext = new DataContext(dbContextOptions);
+
+            dataContext.Database.EnsureDeleted();
+            dataContext.Database.EnsureCreated();
+
+            var unitOfWorkCreate = new UnitOfWork(dataContext);
+            var courseServiceCreate = new CourseService(unitOfWorkCreate);
+            var createdCourse = courseServiceCreate.CreateCourse("AAA", "CourseName", "CourseDescription", DateTime.Now.AddDays(-2), DateTime.Now.AddDays(2));
+
+            var unitOfWorkUpdate = new UnitOfWork(dataContext);
+            var courseServiceUpdate = new CourseService(unitOfWorkUpdate);
+
+
+            courseServiceUpdate.UpdateCourseInfo(createdCourse.Id, "BBB", "ChangedCourseName", "ChangedCourseDescription");
+            courseServiceUpdate.UpdateCoursePeriod(createdCourse.Id, DateTime.Today, DateTime.Today);
+
+            var unitOfWorkGet = new UnitOfWork(dataContext);
+            var courseServiceGet = new CourseService(unitOfWorkGet);
+            var fetchedCourse = courseServiceGet.GetCourse(createdCourse.Id);
+
+            Assert.NotNull(fetchedCourse);
+            Assert.Equal("BBB", createdCourse.Code);
+            Assert.Equal("ChangedCourseName", createdCourse.Name);
+            Assert.Equal("ChangedCourseDescription", createdCourse.Description);
+            Assert.Equal(DateTime.Today, createdCourse.StartDate);
+            Assert.Equal(DateTime.Today, createdCourse.EndDate);
+
+            dataContext.Database.EnsureDeleted();
+        }
+
+
+    }
+
+}


### PR DESCRIPTION
Leaving the issue open to leave room for additions, tests could be seperated into different actions(Create, Read, Update, Delete). Currently there's only one test for creating and updating.

There can also be tests created for the controllers.

Would probably be favourable to use mocking, possibly something like the Moq package.